### PR TITLE
Enable debug logging output when running FastAPI locally

### DIFF
--- a/app_engine_std/cron/app/jobs/_base_job.py
+++ b/app_engine_std/cron/app/jobs/_base_job.py
@@ -2,6 +2,7 @@
 # This file is subject to the terms and conditions defined in the
 # file 'LICENSE', which is part of this source code package.
 #
+import logging
 from services.app_context_manager import GenericJSONStructure
 
 from services.app_context_base import AppEnvContextBase
@@ -9,6 +10,10 @@ from fastapi import HTTPException
 from starlette import status
 
 from aou_cloud.services.system_utils import JSONObject
+
+
+_logger = logging.getLogger('aou_cloud')
+
 
 class BaseCronJob:
     """ Base cron job class """
@@ -25,6 +30,7 @@ class BaseCronJob:
         if payload:
             # Using JSONObject here will convert the binary keys and values in the dict to utf-8.
             self.payload = JSONObject(payload)
+        _logger.info(f'Starting Cron Job: {self.job_name}')
 
     def run(self):
         """

--- a/app_engine_std/cron/app/main.py
+++ b/app_engine_std/cron/app/main.py
@@ -6,6 +6,8 @@
 # Main entry point for cron service micro app
 #
 import logging
+
+from aou_cloud.services.system_utils import setup_logging
 from fastapi import Depends, FastAPI, Request, HTTPException
 from fastapi.responses import JSONResponse
 from fastapi_utils.cbv import cbv
@@ -28,14 +30,14 @@ app = FastAPI()
 
 @app.on_event("startup")
 async def app_startup():
-    # Enable a GCP logging handler if we are running in GCP.
-    if GAE_PROJECT != 'localhost':
+
+    if GAE_PROJECT == 'localhost':
+        setup_logging(_logger, 'fastapi', debug=True)
+    else:
+        # Enable a GCP logging handler if we are running in GCP.
         # Note: Un-comment Simple logger to get full and simple output of everything.
         # enable_gcp_logging(GCPLoggingHandlerEnum.Simple, logging_level, allow_stdout=True)
         enable_gcp_logging(GCPLoggingHandlerEnum.FastAPI, logging.INFO, allow_stdout=False)
-    else:
-        # Running locally, set to debug and console output.
-        enable_gcp_logging(GCPLoggingHandlerEnum.Simple, logging.DEBUG, allow_stdout=False)
 
     # Stop uvicorn from sending random, empty uvicorn access log events.
     logger = logging.getLogger("uvicorn.access")

--- a/app_engine_std/cron/app/tasks/_base_task.py
+++ b/app_engine_std/cron/app/tasks/_base_task.py
@@ -2,7 +2,7 @@
 # This file is subject to the terms and conditions defined in the
 # file 'LICENSE', which is part of this source code package.
 #
-
+import logging
 from services.app_context_manager import GenericJSONStructure
 
 from services.app_context_base import AppEnvContextBase
@@ -10,6 +10,9 @@ from fastapi import HTTPException
 from starlette import status
 
 from aou_cloud.services.system_utils import JSONObject
+
+
+_logger = logging.getLogger('aou_cloud')
 
 
 class BaseCronTask:
@@ -27,6 +30,7 @@ class BaseCronTask:
         if payload:
             # Using JSONObject here will convert the binary keys and values in the dict to utf-8.
             self.payload = JSONObject(payload)
+        _logger.info(f'Starting Cron Task: {self.task_name}')
 
     def run(self):
         """

--- a/app_engine_std/services/app_context_manager.py
+++ b/app_engine_std/services/app_context_manager.py
@@ -73,8 +73,7 @@ class AppEnvContextManager:
 
         if exc_type is not None:
             print((traceback.format_exc()))
-            _logger.error("program encountered an unexpected error, quitting.")
-            exit(1)
+            _logger.error("app encountered an unexpected error")
 
 class AppEnvAsyncContextManager:
     """ Async aware application environment context manager """
@@ -95,7 +94,6 @@ class AppEnvAsyncContextManager:
 
         if exc_type is not None:
             print((traceback.format_exc()))
-            _logger.error("program encountered an unexpected error, quitting.")
-            exit(1)
+            _logger.error("app encountered an unexpected error")
 #
 # End App Context Managers


### PR DESCRIPTION
This change will enable better logging statement output, including debug logging messages, when running the App Engine service locally.